### PR TITLE
Set validate_certs to 'no' for the uri module

### DIFF
--- a/tower_cleanup.yml
+++ b/tower_cleanup.yml
@@ -37,6 +37,7 @@
       password: "{{ student_password }}"
       force_basic_auth: true
       status_code: 204
+      validate_certs: no
     with_items: 
       - "{{ student_towers }}"
     ignore_errors: true
@@ -49,6 +50,7 @@
       password: "{{ student_password }}"
       force_basic_auth: true
       status_code: 204
+      validate_certs: no
     with_items:
       - "{{ student_towers }}"
     ignore_errors: true
@@ -62,6 +64,7 @@
       password: "{{ student_password }}"
       force_basic_auth: true
       status_code: 204
+      validate_certs: no
     with_items:
       - "{{ student_towers }}"
     ignore_errors: true
@@ -74,6 +77,7 @@
       password: "{{ student_password }}"
       force_basic_auth: true
       status_code: 204
+      validate_certs: no
     with_items:
       - "{{ student_towers }}"
     ignore_errors: true
@@ -86,6 +90,7 @@
       password: "{{ student_password }}"
       force_basic_auth: true
       status_code: 204
+      validate_certs: no
     with_items:
       - "{{ student_towers }}"
     ignore_errors: true
@@ -98,6 +103,7 @@
       password: "{{ student_password }}"
       force_basic_auth: true
       status_code: 204
+      validate_certs: no
     with_items:
       - "{{ student_towers }}"
     ignore_errors: true
@@ -121,7 +127,7 @@
           "variables": "",
           "insights_credential": null
         }
+      validate_certs: no
     ignore_errors: true
     with_items:
       - "{{ student_towers }}"
-


### PR DESCRIPTION
This change is needed for Ansible Tower instance provided via RHPDS so that the clean up tasks will not error out